### PR TITLE
Improved way to generate an ElementMesh.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # MacOS files
 .DS_Store
 */.DS_Store
+#vim swap files
+*.swp
+*.swo
 
 build


### PR DESCRIPTION
This commit improves the way an ElementMesh is generated. It removed the Quiet and fixes the way the incidents are given to ToElementMesh. That way only valid ElementMesh are generated. In the previous version the use of Quiet and the options given to the mesh generation were hiding away issues. The current code passes the test suite.